### PR TITLE
Fix for util.AddNetworkString

### DIFF
--- a/gamemodes/fretta13/gamemode/init.lua
+++ b/gamemodes/fretta13/gamemode/init.lua
@@ -37,12 +37,11 @@ include( "utility.lua" )
 
 GM.ReconnectedPlayers = {}
 
-function GM:Initialize()
+util.AddNetworkString("PlayableGamemodes")
+util.AddNetworkString("RoundAddedTime")
+util.AddNetworkString("fretta_teamchange")
 
-	util.AddNetworkString("PlayableGamemodes")
-	util.AddNetworkString("RoundAddedTime")
-	util.AddNetworkString("PlayableGamemodes")
-	util.AddNetworkString("fretta_teamchange")
+function GM:Initialize()
 
 	-- If we're round based, wait 3 seconds before the first round starts
 	if ( GAMEMODE.RoundBased ) then


### PR DESCRIPTION
According to http://wiki.garrysmod.com/page/util/AddNetworkString, "it's preferable to call this function as soon as the server starts up"
Calling this function in GM:Initialize() causing error: "Calling net.Start with unpooled message name!"
Also removed duplicated util.AddNetworkString("PlayableGamemodes")
